### PR TITLE
feat(tui): implement views for projects, queue, budget, and events (s…

### DIFF
--- a/src/tui/feed.rs
+++ b/src/tui/feed.rs
@@ -1,4 +1,4 @@
-use crate::models::{ActionId, BackendId, EventId, ProjectId, TaskId};
+use crate::models::{ActionId, BackendId, EventId, ProjectId};
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -112,7 +112,7 @@ impl FeedFilter {
             FeedFilter::Blocked => "blocked",
             FeedFilter::Budget => "budget",
             FeedFilter::Unread => "unread",
-            FeedFilter::Project(id) => "project",
+            FeedFilter::Project(_) => "project",
         }
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -17,8 +17,6 @@ pub mod types {
 }
 
 const SIDEBAR_WIDTH: u16 = 30;
-const MIN_TERMINAL_WIDTH: u16 = 100;
-const MIN_TERMINAL_HEIGHT: u16 = 24;
 const HEADER_HEIGHT: u16 = 1;
 const COMPOSER_HEIGHT: u16 = 3;
 const FOOTER_HEIGHT: u16 = 1;

--- a/src/tui/update.rs
+++ b/src/tui/update.rs
@@ -127,11 +127,136 @@ fn find_prev_visible_feed_item(
     }
 }
 
-fn resolve_feed_index(state: &AppState, filtered: &[&FeedItem]) -> Option<usize> {
+fn handle_navigation_down(state: &mut AppState) {
+    match state.current_tab {
+        TopLevelTab::Chats => match state.focused {
+            FocusRegion::Projects => {
+                if state.chats_view.selected_project_index < state.projects.len().saturating_sub(1)
+                {
+                    state.chats_view.selected_project_index += 1;
+                }
+            }
+            FocusRegion::Filters => {
+                if state.chats_view.selected_filter_index < FILTERS.len() - 1 {
+                    state.chats_view.selected_filter_index += 1;
+                    update_active_filter(state);
+                }
+            }
+            FocusRegion::Feed => {
+                let current_id = state.chats_view.selected_feed_id;
+                state.chats_view.selected_feed_id = find_next_visible_feed_item(state, current_id);
+            }
+            _ => {}
+        },
+        TopLevelTab::Projects => {
+            if state.projects_view.selected_index < state.projects.len().saturating_sub(1) {
+                state.projects_view.selected_index += 1;
+            }
+        }
+        TopLevelTab::Queue => {
+            let count = count_filtered_actions(state);
+            if count > 0 && state.queue_view.selected_index < count - 1 {
+                state.queue_view.selected_index += 1;
+            }
+        }
+        TopLevelTab::Budget => {}
+        TopLevelTab::Events => {
+            if state.events_view.scroll_offset < state.events.len().saturating_sub(1) {
+                state.events_view.scroll_offset += 1;
+            }
+        }
+    }
+}
+
+fn handle_navigation_up(state: &mut AppState) {
+    match state.current_tab {
+        TopLevelTab::Chats => match state.focused {
+            FocusRegion::Projects => {
+                if state.chats_view.selected_project_index > 0 {
+                    state.chats_view.selected_project_index -= 1;
+                }
+            }
+            FocusRegion::Filters => {
+                if state.chats_view.selected_filter_index > 0 {
+                    state.chats_view.selected_filter_index -= 1;
+                    update_active_filter(state);
+                }
+            }
+            FocusRegion::Feed => {
+                let current_id = state.chats_view.selected_feed_id;
+                state.chats_view.selected_feed_id = find_prev_visible_feed_item(state, current_id);
+            }
+            _ => {}
+        },
+        TopLevelTab::Projects => {
+            if state.projects_view.selected_index > 0 {
+                state.projects_view.selected_index -= 1;
+            }
+        }
+        TopLevelTab::Queue => {
+            if state.queue_view.selected_index > 0 {
+                state.queue_view.selected_index -= 1;
+            }
+        }
+        TopLevelTab::Budget => {}
+        TopLevelTab::Events => {
+            if state.events_view.scroll_offset > 0 {
+                state.events_view.scroll_offset -= 1;
+            }
+        }
+    }
+}
+
+fn count_filtered_actions(state: &AppState) -> usize {
     state
-        .chats_view
-        .selected_feed_id
-        .and_then(|id| filtered.iter().position(|item| item.id == id))
+        .actions
+        .iter()
+        .filter(|a| !a.resolved && action_matches_filter(a.kind, state.queue_view.selected_filter))
+        .count()
+}
+
+fn action_matches_filter(
+    kind: crate::tui::domain::ActionKind,
+    filter: crate::tui::state::QueueFilter,
+) -> bool {
+    use crate::tui::domain::ActionKind;
+    use crate::tui::state::QueueFilter;
+
+    match filter {
+        QueueFilter::All => true,
+        QueueFilter::Review => kind == ActionKind::ReviewRequest,
+        QueueFilter::Commit => kind == ActionKind::CommitSuggestion,
+        QueueFilter::Blocker => kind == ActionKind::Blocker,
+        QueueFilter::Budget => kind == ActionKind::BudgetApproval,
+    }
+}
+
+fn cycle_queue_filter_left(state: &mut AppState) {
+    use crate::tui::state::QueueFilter;
+
+    let new_filter = match state.queue_view.selected_filter {
+        QueueFilter::All => QueueFilter::Budget,
+        QueueFilter::Review => QueueFilter::All,
+        QueueFilter::Commit => QueueFilter::Review,
+        QueueFilter::Blocker => QueueFilter::Commit,
+        QueueFilter::Budget => QueueFilter::Blocker,
+    };
+    state.queue_view.selected_filter = new_filter;
+    state.queue_view.selected_index = 0;
+}
+
+fn cycle_queue_filter_right(state: &mut AppState) {
+    use crate::tui::state::QueueFilter;
+
+    let new_filter = match state.queue_view.selected_filter {
+        QueueFilter::All => QueueFilter::Review,
+        QueueFilter::Review => QueueFilter::Commit,
+        QueueFilter::Commit => QueueFilter::Blocker,
+        QueueFilter::Blocker => QueueFilter::Budget,
+        QueueFilter::Budget => QueueFilter::All,
+    };
+    state.queue_view.selected_filter = new_filter;
+    state.queue_view.selected_index = 0;
 }
 
 fn handle_normal_mode(
@@ -170,43 +295,12 @@ fn handle_normal_mode(
                 FocusRegion::Composer => FocusRegion::Feed,
             };
         }
-        KeyCode::Char('j') | KeyCode::Down => match state.focused {
-            FocusRegion::Projects => {
-                if state.chats_view.selected_project_index < state.projects.len().saturating_sub(1)
-                {
-                    state.chats_view.selected_project_index += 1;
-                }
-            }
-            FocusRegion::Filters => {
-                if state.chats_view.selected_filter_index < FILTERS.len() - 1 {
-                    state.chats_view.selected_filter_index += 1;
-                    update_active_filter(state);
-                }
-            }
-            FocusRegion::Feed => {
-                let current_id = state.chats_view.selected_feed_id;
-                state.chats_view.selected_feed_id = find_next_visible_feed_item(state, current_id);
-            }
-            _ => {}
-        },
-        KeyCode::Char('k') | KeyCode::Up => match state.focused {
-            FocusRegion::Projects => {
-                if state.chats_view.selected_project_index > 0 {
-                    state.chats_view.selected_project_index -= 1;
-                }
-            }
-            FocusRegion::Filters => {
-                if state.chats_view.selected_filter_index > 0 {
-                    state.chats_view.selected_filter_index -= 1;
-                    update_active_filter(state);
-                }
-            }
-            FocusRegion::Feed => {
-                let current_id = state.chats_view.selected_feed_id;
-                state.chats_view.selected_feed_id = find_prev_visible_feed_item(state, current_id);
-            }
-            _ => {}
-        },
+        KeyCode::Char('j') | KeyCode::Down => {
+            handle_navigation_down(state);
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            handle_navigation_up(state);
+        }
         KeyCode::Char('i') => {
             state.mode = UiMode::Input;
             state.focused = FocusRegion::Composer;
@@ -214,6 +308,16 @@ fn handle_normal_mode(
         KeyCode::Enter => {
             if state.focused == FocusRegion::Feed {
                 state.mode = UiMode::Detail;
+            }
+        }
+        KeyCode::Char('h') | KeyCode::Left => {
+            if state.current_tab == TopLevelTab::Queue {
+                cycle_queue_filter_left(state);
+            }
+        }
+        KeyCode::Char('l') | KeyCode::Right => {
+            if state.current_tab == TopLevelTab::Queue {
+                cycle_queue_filter_right(state);
             }
         }
         KeyCode::Esc => {

--- a/src/tui/views/budget_view.rs
+++ b/src/tui/views/budget_view.rs
@@ -1,35 +1,127 @@
 use ratatui::{
-    layout::Rect,
-    style::Style,
-    widgets::{Block, Borders, Paragraph},
+    layout::{Constraint, Direction, Layout, Rect},
+    widgets::{Block, Borders, Paragraph, Wrap},
     Frame,
 };
 
 use crate::tui::state::AppState;
 
 pub fn render_budget_view(f: &mut Frame, area: Rect, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(6),
+            Constraint::Length(8),
+            Constraint::Min(10),
+        ])
+        .split(area);
+
+    render_global_budget(f, chunks[0], state);
+    render_backend_budget(f, chunks[1], state);
+    render_project_budget(f, chunks[2], state);
+}
+
+fn render_global_budget(f: &mut Frame, area: Rect, state: &AppState) {
+    let percent = state.budget.global_percent_used;
+    let bar = progress_bar(percent, 30);
+
+    let mode = format!("{:?}", state.budget.mode);
+    let warning_count = state.budget.warnings.len();
+
     let mut lines = vec![
-        format!(
-            "Global Budget: {:.0}%",
-            state.budget.global_percent_used * 100.0
-        ),
-        format!("Mode: {:?}", state.budget.mode),
+        format!("Mode: {}  Warnings: {}", mode, warning_count),
+        format!("Global Budget: {:.0}%", percent * 100.0),
+        format!("[{}]", bar),
     ];
 
-    for (backend, percent) in &state.budget.backend_percent_used {
-        lines.push(format!("{}: {:.0}%", backend, percent * 100.0));
-    }
-
     if let Some(rate) = &state.budget.daily_burn_rate {
-        lines.push(format!("Daily burn: {}", rate));
+        lines.push(format!(
+            "Daily burn rate: ${:.2}",
+            rate.cents as f64 / 100.0
+        ));
     }
 
     if let Some(projected) = &state.budget.projected_eom {
-        lines.push(format!("Projected EOM: {}", projected));
+        lines.push(format!(
+            "Projected EOM: ${:.2}",
+            projected.cents as f64 / 100.0
+        ));
     }
 
     let text = lines.join("\n");
-    let paragraph =
-        Paragraph::new(text).block(Block::default().title("Budget").borders(Borders::ALL));
+    let paragraph = Paragraph::new(text)
+        .block(
+            Block::default()
+                .title("Global Budget")
+                .borders(Borders::ALL),
+        )
+        .wrap(Wrap::default());
     f.render_widget(paragraph, area);
+}
+
+fn render_backend_budget(f: &mut Frame, area: Rect, state: &AppState) {
+    let mut lines = Vec::new();
+
+    if state.budget.backend_percent_used.is_empty() {
+        lines.push("No backend data available".to_string());
+    } else {
+        lines.push("Backend Usage:".to_string());
+        for (backend, percent) in &state.budget.backend_percent_used {
+            let bar = progress_bar(*percent, 20);
+            lines.push(format!("  {}: [{}] {:.0}%", backend, bar, percent * 100.0));
+        }
+    }
+
+    let text = lines.join("\n");
+    let paragraph = Paragraph::new(text)
+        .block(
+            Block::default()
+                .title("Backend Budget")
+                .borders(Borders::ALL),
+        )
+        .wrap(Wrap::default());
+    f.render_widget(paragraph, area);
+}
+
+fn render_project_budget(f: &mut Frame, area: Rect, state: &AppState) {
+    let mut lines = vec!["Project Budget Usage:".to_string()];
+
+    let mut sorted: Vec<_> = state.projects.iter().collect();
+    sorted.sort_by(|a, b| {
+        b.budget_percent
+            .partial_cmp(&a.budget_percent)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let top_projects: Vec<_> = sorted.iter().take(10).collect();
+
+    if top_projects.is_empty() {
+        lines.push("  (no projects)".to_string());
+    } else {
+        for p in top_projects {
+            let bar = progress_bar(p.budget_percent, 15);
+            lines.push(format!(
+                "  {}: [{}] {:.0}%",
+                p.name,
+                bar,
+                p.budget_percent * 100.0
+            ));
+        }
+    }
+
+    let text = lines.join("\n");
+    let paragraph = Paragraph::new(text)
+        .block(
+            Block::default()
+                .title("Project Budget")
+                .borders(Borders::ALL),
+        )
+        .wrap(Wrap::default());
+    f.render_widget(paragraph, area);
+}
+
+fn progress_bar(percent: f32, width: usize) -> String {
+    let filled = ((percent.clamp(0.0, 1.0) * width as f32) as usize).min(width);
+    let empty = width - filled;
+    format!("{}{}", "█".repeat(filled), "░".repeat(empty))
 }

--- a/src/tui/views/events_view.rs
+++ b/src/tui/views/events_view.rs
@@ -1,10 +1,64 @@
-use ratatui::{layout::Rect, Frame};
+use ratatui::{
+    layout::Rect,
+    style::{Modifier, Style},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    Frame,
+};
 
 use crate::tui::state::AppState;
 
-pub fn render_events_view(f: &mut Frame, area: Rect, _state: &AppState) {
-    let block = ratatui::widgets::Block::default()
-        .title("Events")
-        .borders(ratatui::widgets::Borders::ALL);
-    f.render_widget(block, area);
+pub fn render_events_view(f: &mut Frame, area: Rect, state: &AppState) {
+    let filtered: Vec<_> = if let Some(filter) = &state.events_view.filter {
+        state
+            .events
+            .iter()
+            .filter(|e| e.event_type.contains(filter))
+            .collect()
+    } else {
+        state.events.iter().collect()
+    };
+
+    if filtered.is_empty() {
+        let empty = if state.events.is_empty() {
+            "No events recorded"
+        } else {
+            "No events match filter"
+        };
+        let paragraph = Paragraph::new(empty)
+            .style(Style::default().add_modifier(Modifier::DIM))
+            .block(Block::default().title("Events").borders(Borders::ALL));
+        f.render_widget(paragraph, area);
+        return;
+    }
+
+    let items: Vec<ListItem> = filtered
+        .iter()
+        .enumerate()
+        .map(|(i, event)| {
+            let style = if i == state.events_view.scroll_offset {
+                Style::default().add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+
+            let time = event.timestamp.format("%H:%M:%S");
+            let text = format!(
+                "[{}] {} {}",
+                time,
+                event.event_type,
+                event.payload.chars().take(60).collect::<String>()
+            );
+            ListItem::new(text).style(style)
+        })
+        .collect();
+
+    let list = List::new(items).block(
+        Block::default()
+            .title(format!("Events ({})", filtered.len()))
+            .borders(Borders::ALL),
+    );
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.events_view.scroll_offset));
+    f.render_stateful_widget(list, area, &mut list_state);
 }

--- a/src/tui/views/mod.rs
+++ b/src/tui/views/mod.rs
@@ -1,11 +1,9 @@
 mod budget_view;
-mod chats;
 mod events_view;
 mod projects_view;
 mod queue;
 
 pub use budget_view::render_budget_view;
-pub use chats::render_chats_view;
 pub use events_view::render_events_view;
 pub use projects_view::render_projects_view;
 pub use queue::render_queue_view;

--- a/src/tui/views/projects_view.rs
+++ b/src/tui/views/projects_view.rs
@@ -1,10 +1,118 @@
-use ratatui::{layout::Rect, Frame};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    Frame,
+};
 
 use crate::tui::state::AppState;
 
-pub fn render_projects_view(f: &mut Frame, area: Rect, _state: &AppState) {
-    let block = ratatui::widgets::Block::default()
-        .title("Projects")
-        .borders(ratatui::widgets::Borders::ALL);
-    f.render_widget(block, area);
+pub fn render_projects_view(f: &mut Frame, area: Rect, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(35), Constraint::Percentage(65)])
+        .split(area);
+
+    render_project_list(f, chunks[0], state);
+    render_project_detail(f, chunks[1], state);
+}
+
+fn render_project_list(f: &mut Frame, area: Rect, state: &AppState) {
+    let items: Vec<ListItem> = state
+        .projects
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            let selected = i == state.projects_view.selected_index;
+            let style = if selected {
+                Style::default().add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let marker = p.status.marker();
+            let count = if p.unread_count > 0 {
+                format!(" ({})", p.unread_count)
+            } else {
+                String::new()
+            };
+            ListItem::new(format!("{} {}{}", marker, p.name, count)).style(style)
+        })
+        .collect();
+
+    let list = List::new(items).block(Block::default().title("Projects").borders(Borders::ALL));
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.projects_view.selected_index));
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn render_project_detail(f: &mut Frame, area: Rect, state: &AppState) {
+    let project = state.projects.get(state.projects_view.selected_index);
+
+    let content = match project {
+        Some(p) => build_project_detail(p, state),
+        None => vec!["No project selected".to_string()],
+    };
+
+    let text = content.join("\n");
+    let paragraph = Paragraph::new(text).block(
+        Block::default()
+            .title("Project Detail")
+            .borders(Borders::ALL),
+    );
+    f.render_widget(paragraph, area);
+}
+
+fn build_project_detail(
+    project: &crate::tui::domain::ProjectState,
+    state: &AppState,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    lines.push(format!("Name: {}", project.name));
+    lines.push(format!("ID: {}", project.id));
+    lines.push(format!("Status: {:?}", project.status));
+    lines.push(String::new());
+
+    lines.push(format!(
+        "Backend: {}",
+        project
+            .default_backend
+            .as_ref()
+            .map(|b| b.to_string())
+            .unwrap_or_else(|| "none".to_string())
+    ));
+    lines.push(format!("Budget: {:.1}%", project.budget_percent * 100.0));
+    lines.push(String::new());
+
+    lines.push(format!("Pending Tasks: {}", project.unread_count));
+    lines.push(format!("Pending Actions: {}", project.pending_actions));
+
+    if let Some(last) = &project.last_activity {
+        lines.push(format!("Last Activity: {}", last.format("%Y-%m-%d %H:%M")));
+    }
+
+    lines.push(String::new());
+    lines.push("Recent Feed Items:".to_string());
+
+    let recent: Vec<_> = state
+        .feed
+        .iter()
+        .filter(|item| item.project_id == project.id)
+        .take(5)
+        .collect();
+
+    if recent.is_empty() {
+        lines.push("  (no recent items)".to_string());
+    } else {
+        for item in recent {
+            lines.push(format!(
+                "  [{}] {}",
+                item.kind.as_str(),
+                item.summary.chars().take(50).collect::<String>()
+            ));
+        }
+    }
+
+    lines
 }

--- a/src/tui/views/queue.rs
+++ b/src/tui/views/queue.rs
@@ -1,10 +1,113 @@
-use ratatui::{layout::Rect, Frame};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    Frame,
+};
 
-use crate::tui::state::AppState;
+use crate::tui::domain::ActionKind;
+use crate::tui::state::{AppState, QueueFilter};
 
-pub fn render_queue_view(f: &mut Frame, area: Rect, _state: &AppState) {
-    let block = ratatui::widgets::Block::default()
-        .title("Queue")
-        .borders(ratatui::widgets::Borders::ALL);
-    f.render_widget(block, area);
+const QUEUE_FILTERS: &[QueueFilter] = &[
+    QueueFilter::All,
+    QueueFilter::Review,
+    QueueFilter::Commit,
+    QueueFilter::Blocker,
+    QueueFilter::Budget,
+];
+
+pub fn render_queue_view(f: &mut Frame, area: Rect, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(12), Constraint::Min(40)])
+        .split(area);
+
+    render_filter_panel(f, chunks[0], state);
+    render_action_list(f, chunks[1], state);
+}
+
+fn render_filter_panel(f: &mut Frame, area: Rect, state: &AppState) {
+    let items: Vec<ListItem> = QUEUE_FILTERS
+        .iter()
+        .map(|filter| {
+            let selected = *filter == state.queue_view.selected_filter;
+            let style = if selected {
+                Style::default().add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let label = match filter {
+                QueueFilter::All => "all",
+                QueueFilter::Review => "review",
+                QueueFilter::Commit => "commit",
+                QueueFilter::Blocker => "blocker",
+                QueueFilter::Budget => "budget",
+            };
+            let prefix = if selected { "[" } else { " " };
+            let suffix = if selected { "]" } else { "" };
+            ListItem::new(format!("{}{}{}", prefix, label, suffix)).style(style)
+        })
+        .collect();
+
+    let list = List::new(items).block(Block::default().title("Filter").borders(Borders::ALL));
+    f.render_widget(list, area);
+}
+
+fn render_action_list(f: &mut Frame, area: Rect, state: &AppState) {
+    let filtered: Vec<_> = state
+        .actions
+        .iter()
+        .filter(|a| !a.resolved && action_matches_filter(a.kind, state.queue_view.selected_filter))
+        .collect();
+
+    if filtered.is_empty() {
+        let empty = Paragraph::new("No pending actions")
+            .style(Style::default().add_modifier(Modifier::DIM))
+            .block(Block::default().title("Actions").borders(Borders::ALL));
+        f.render_widget(empty, area);
+        return;
+    }
+
+    let items: Vec<ListItem> = filtered
+        .iter()
+        .enumerate()
+        .map(|(i, action)| {
+            let selected = i == state.queue_view.selected_index;
+            let style = if selected {
+                Style::default().add_modifier(Modifier::BOLD)
+            } else if action.requires_user_decision {
+                Style::default()
+            } else {
+                Style::default().add_modifier(Modifier::DIM)
+            };
+
+            let text = format!(
+                "[{}] {}: {}",
+                action.kind.as_str(),
+                action.project_name,
+                action.summary
+            );
+            ListItem::new(text).style(style)
+        })
+        .collect();
+
+    let list = List::new(items).block(Block::default().title("Actions").borders(Borders::ALL));
+
+    let mut list_state = ListState::default();
+    let select_idx = state
+        .queue_view
+        .selected_index
+        .min(filtered.len().saturating_sub(1));
+    list_state.select(Some(select_idx));
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn action_matches_filter(kind: ActionKind, filter: QueueFilter) -> bool {
+    match filter {
+        QueueFilter::All => true,
+        QueueFilter::Review => kind == ActionKind::ReviewRequest,
+        QueueFilter::Commit => kind == ActionKind::CommitSuggestion,
+        QueueFilter::Blocker => kind == ActionKind::Blocker,
+        QueueFilter::Budget => kind == ActionKind::BudgetApproval,
+    }
 }

--- a/tests/tui_tests.rs
+++ b/tests/tui_tests.rs
@@ -735,3 +735,265 @@ fn test_explicit_project_prefix_routes_correctly() {
         assert_eq!(description, "fix the header");
     }
 }
+
+#[test]
+fn test_projects_view_navigation() {
+    use strategos::models::ProjectId;
+    use strategos::tui::domain::{ProjectState, ProjectStatus};
+
+    let mut state = create_test_state();
+    state.current_tab = TopLevelTab::Projects;
+    state.projects = vec![
+        ProjectState {
+            id: ProjectId::new(),
+            name: "project_alpha".to_string(),
+            status: ProjectStatus::Healthy,
+            unread_count: 5,
+            pending_actions: 1,
+            default_backend: None,
+            last_activity: None,
+            budget_percent: 0.0,
+        },
+        ProjectState {
+            id: ProjectId::new(),
+            name: "project_beta".to_string(),
+            status: ProjectStatus::AwaitingReview,
+            unread_count: 2,
+            pending_actions: 0,
+            default_backend: None,
+            last_activity: None,
+            budget_percent: 0.45,
+        },
+    ];
+    let mut tick_count = 0;
+
+    let down = crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Down,
+        crossterm::event::KeyModifiers::NONE,
+    );
+    let up = crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Up,
+        crossterm::event::KeyModifiers::NONE,
+    );
+
+    // Start at index 0
+    assert_eq!(state.projects_view.selected_index, 0);
+
+    // Navigate down
+    update(&mut state, UiEvent::Key(down.clone()), &mut tick_count);
+    assert_eq!(state.projects_view.selected_index, 1);
+
+    // Bounds check - can't go past end
+    update(&mut state, UiEvent::Key(down.clone()), &mut tick_count);
+    assert_eq!(state.projects_view.selected_index, 1);
+
+    // Navigate back up
+    update(&mut state, UiEvent::Key(up.clone()), &mut tick_count);
+    assert_eq!(state.projects_view.selected_index, 0);
+
+    // Bounds check - can't go before start
+    update(&mut state, UiEvent::Key(up.clone()), &mut tick_count);
+    assert_eq!(state.projects_view.selected_index, 0);
+}
+
+#[test]
+fn test_queue_view_navigation() {
+    use strategos::models::{ActionId, ProjectId};
+    use strategos::tui::domain::{ActionItem, ActionKind};
+    use strategos::tui::state::QueueFilter;
+
+    let mut state = create_test_state();
+    state.current_tab = TopLevelTab::Queue;
+    state.actions = vec![
+        ActionItem {
+            id: ActionId::new(),
+            project_id: ProjectId::new(),
+            project_name: "test".to_string(),
+            kind: ActionKind::ReviewRequest,
+            priority: strategos::models::Priority::Normal,
+            summary: "Review code changes".to_string(),
+            created_at: chrono::Utc::now(),
+            requires_user_decision: true,
+            resolved: false,
+        },
+        ActionItem {
+            id: ActionId::new(),
+            project_id: ProjectId::new(),
+            project_name: "test".to_string(),
+            kind: ActionKind::CommitSuggestion,
+            priority: strategos::models::Priority::Normal,
+            summary: "Commit ready".to_string(),
+            created_at: chrono::Utc::now(),
+            requires_user_decision: true,
+            resolved: false,
+        },
+    ];
+    let mut tick_count = 0;
+
+    let down = crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Down,
+        crossterm::event::KeyModifiers::NONE,
+    );
+    let up = crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Up,
+        crossterm::event::KeyModifiers::NONE,
+    );
+
+    // Navigate through actions
+    update(&mut state, UiEvent::Key(down.clone()), &mut tick_count);
+    assert_eq!(state.queue_view.selected_index, 1);
+
+    update(&mut state, UiEvent::Key(up.clone()), &mut tick_count);
+    assert_eq!(state.queue_view.selected_index, 0);
+}
+
+#[test]
+fn test_queue_filter_cycling() {
+    use strategos::tui::state::QueueFilter;
+
+    let mut state = create_test_state();
+    state.current_tab = TopLevelTab::Queue;
+    let mut tick_count = 0;
+
+    let right = crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Right,
+        crossterm::event::KeyModifiers::NONE,
+    );
+    let left = crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Left,
+        crossterm::event::KeyModifiers::NONE,
+    );
+
+    // Default filter is All
+    assert_eq!(state.queue_view.selected_filter, QueueFilter::All);
+
+    // Cycle right: All -> Review
+    update(&mut state, UiEvent::Key(right.clone()), &mut tick_count);
+    assert_eq!(state.queue_view.selected_filter, QueueFilter::Review);
+
+    // Cycle right: Review -> Commit
+    update(&mut state, UiEvent::Key(right.clone()), &mut tick_count);
+    assert_eq!(state.queue_view.selected_filter, QueueFilter::Commit);
+
+    // Cycle right: Commit -> Blocker
+    update(&mut state, UiEvent::Key(right.clone()), &mut tick_count);
+    assert_eq!(state.queue_view.selected_filter, QueueFilter::Blocker);
+
+    // Cycle right: Blocker -> Budget
+    update(&mut state, UiEvent::Key(right.clone()), &mut tick_count);
+    assert_eq!(state.queue_view.selected_filter, QueueFilter::Budget);
+
+    // Cycle right: Budget -> All (wrap)
+    update(&mut state, UiEvent::Key(right.clone()), &mut tick_count);
+    assert_eq!(state.queue_view.selected_filter, QueueFilter::All);
+
+    // Cycle left: All -> Budget (wrap)
+    update(&mut state, UiEvent::Key(left.clone()), &mut tick_count);
+    assert_eq!(state.queue_view.selected_filter, QueueFilter::Budget);
+}
+
+#[test]
+fn test_events_view_navigation() {
+    use strategos::tui::state::EventRecord;
+
+    let mut state = create_test_state();
+    state.current_tab = TopLevelTab::Events;
+    state.events = vec![
+        EventRecord {
+            id: uuid::Uuid::new_v4(),
+            event_type: "TaskCreated".to_string(),
+            timestamp: chrono::Utc::now(),
+            payload: "test payload 1".to_string(),
+        },
+        EventRecord {
+            id: uuid::Uuid::new_v4(),
+            event_type: "TaskCompleted".to_string(),
+            timestamp: chrono::Utc::now(),
+            payload: "test payload 2".to_string(),
+        },
+    ];
+    let mut tick_count = 0;
+
+    let down = crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Down,
+        crossterm::event::KeyModifiers::NONE,
+    );
+    let up = crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Up,
+        crossterm::event::KeyModifiers::NONE,
+    );
+
+    // Navigate through events
+    update(&mut state, UiEvent::Key(down.clone()), &mut tick_count);
+    assert_eq!(state.events_view.scroll_offset, 1);
+
+    update(&mut state, UiEvent::Key(up.clone()), &mut tick_count);
+    assert_eq!(state.events_view.scroll_offset, 0);
+}
+
+#[test]
+fn test_budget_view_displays_percentages() {
+    use strategos::budget::governor::BudgetMode;
+    use strategos::models::{BackendId, MoneyAmount};
+
+    let mut state = create_test_state();
+    state.current_tab = TopLevelTab::Budget;
+    state.budget.global_percent_used = 0.65;
+    state.budget.mode = BudgetMode::Govern;
+    state.budget.daily_burn_rate = Some(MoneyAmount { cents: 50000 });
+    state.budget.projected_eom = Some(MoneyAmount { cents: 150000 });
+
+    let backend_id = BackendId::new("claude");
+    state.budget.backend_percent_used.insert(backend_id, 0.35);
+
+    // Just verify the state is set correctly
+    assert!((state.budget.global_percent_used - 0.65).abs() < 0.01);
+    assert_eq!(state.budget.mode, BudgetMode::Govern);
+    assert!(state.budget.daily_burn_rate.is_some());
+    assert!(state.budget.projected_eom.is_some());
+}
+
+#[test]
+fn test_queue_filter_resets_selection() {
+    use strategos::models::{ActionId, ProjectId};
+    use strategos::tui::domain::{ActionItem, ActionKind};
+    use strategos::tui::state::QueueFilter;
+
+    let mut state = create_test_state();
+    state.current_tab = TopLevelTab::Queue;
+    state.actions = vec![
+        ActionItem {
+            id: ActionId::new(),
+            project_id: ProjectId::new(),
+            project_name: "test".to_string(),
+            kind: ActionKind::ReviewRequest,
+            priority: strategos::models::Priority::Normal,
+            summary: "Review item".to_string(),
+            created_at: chrono::Utc::now(),
+            requires_user_decision: true,
+            resolved: false,
+        },
+        ActionItem {
+            id: ActionId::new(),
+            project_id: ProjectId::new(),
+            project_name: "test".to_string(),
+            kind: ActionKind::CommitSuggestion,
+            priority: strategos::models::Priority::Normal,
+            summary: "Commit item".to_string(),
+            created_at: chrono::Utc::now(),
+            requires_user_decision: true,
+            resolved: false,
+        },
+    ];
+    state.queue_view.selected_index = 1;
+    let mut tick_count = 0;
+
+    let right = crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Right,
+        crossterm::event::KeyModifiers::NONE,
+    );
+
+    // Change filter - selection should reset to 0
+    update(&mut state, UiEvent::Key(right.clone()), &mut tick_count);
+    assert_eq!(state.queue_view.selected_index, 0);
+}


### PR DESCRIPTION
…teps 60-63)

closed #92 - Projects View (step 60):
- Two-panel layout with project list and detail panel
- Shows status, backend, budget, pending tasks, recent feed items closed #93 - Queue View (step 61):
- List of pending actions with filter panel
- h/l keys cycle through filters (All, Review, Commit, Blocker, Budget)
- Filter change resets selection to first item closed #94 - Budget View (step 62):
- Global budget with progress bar and mode display
- Per-backend usage statistics
- Top 10 projects by budget consumption closed #95 - Events View (step 63):
- Chronological event log with timestamps
- Scrollable with j/k navigation
- Optional type filtering support Navigation updates:
- j/k and arrows now context-aware based on current tab
- Extended navigation to all new views Added 6 new tests, total 29 TUI tests passing.